### PR TITLE
Feature: Save and Restore Metadata to JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,26 @@ Will display metadata on the screen, by default in a human-readable format.
 Optionally, a `--format` flag can be passed to format the metadata to be passed
 directly to an encoder.
 
+### Save metadata
+
+`hdrcopier save [input] [target]`
+
+- input = file to copy metadata from
+- target = json file to save metadata to
+
+Will parse the metadata from the input file,
+then save the metadata as JSON and write to the target file.
+
+### Restore metadata
+
+`hdrcopier restore [input] [target]`
+
+- input = json file with saved metadata
+- target = file to copy metadata into
+
+Will read metadata from the json file,
+then update the target file with that metadata.
+
 ## Bugs
 
 If you have a video that you know is HDR, but this tool fails to parse the metadata,

--- a/hdrcopier-cli/Cargo.toml
+++ b/hdrcopier-cli/Cargo.toml
@@ -18,3 +18,6 @@ path = "src/main.rs"
 [dependencies]
 hdrcopier-core = { path = "../hdrcopier-core" }
 clap = "3.0.13"
+
+[features]
+save = ["hdrcopier-core/save"]

--- a/hdrcopier-cli/src/main.rs
+++ b/hdrcopier-cli/src/main.rs
@@ -46,8 +46,54 @@ fn main() {
                         .takes_value(true)
                         .possible_values(["x265", "rav1e", "mkvmerge"]),
                 ),
+        );
+    #[cfg(feature = "save")]
+    let args = args
+        .subcommand(
+            Command::new("save")
+                .about("Saves the metadata from a file to a JSON file")
+                .arg(
+                    Arg::new("input")
+                        .help("file to save metadata from; must be a matroska file")
+                        .required(true)
+                        .index(1),
+                )
+                .arg(
+                    Arg::new("target")
+                        .help("file to save metadata to; must be a JSON file")
+                        .required(true)
+                        .index(2),
+                )
+                .arg(
+                    Arg::new("chapters")
+                        .help("Also save chapters from input to output")
+                        .long("chapters")
+                        .takes_value(false),
+                ),
         )
-        .get_matches();
+        .subcommand(
+            Command::new("restore")
+                .about("Restores the metadata from a JSON file to a file")
+                .arg(
+                    Arg::new("input")
+                        .help("file to restore metadata from; must be a JSON file")
+                        .required(true)
+                        .index(1),
+                )
+                .arg(
+                    Arg::new("target")
+                        .help("file to restore metadata to; must be a matroska file")
+                        .required(true)
+                        .index(2),
+                )
+                .arg(
+                    Arg::new("chapters")
+                        .help("Also restore chapters from input to output")
+                        .long("chapters")
+                        .takes_value(false),
+                ),
+        );
+    let args = args.get_matches();
 
     match args.subcommand_name() {
         Some("copy") => {
@@ -64,6 +110,26 @@ fn main() {
             let input = PathBuf::from(&sub_args.value_of("input").expect("Value required by clap"));
 
             hdrcopier_core::show(input, sub_args.value_of("format"))
+        }
+        #[cfg(feature = "save")]
+        Some("save") => {
+            let sub_args = args.subcommand_matches("save").unwrap();
+            let input = PathBuf::from(&sub_args.value_of("input").expect("Value required by clap"));
+            let target =
+                PathBuf::from(&sub_args.value_of("target").expect("Value required by clap"));
+            let chapters = sub_args.is_present("chapters");
+
+            hdrcopier_core::save(input, target, chapters)
+        }
+        #[cfg(feature = "save")]
+        Some("restore") => {
+            let sub_args = args.subcommand_matches("restore").unwrap();
+            let input = PathBuf::from(&sub_args.value_of("input").expect("Value required by clap"));
+            let target =
+                PathBuf::from(&sub_args.value_of("target").expect("Value required by clap"));
+            let chapters = sub_args.is_present("chapters");
+
+            hdrcopier_core::restore(input, target, chapters)
         }
         _ => {
             eprintln!("Unrecognized command entered; see `hdrcopier -h` for usage");

--- a/hdrcopier-core/Cargo.toml
+++ b/hdrcopier-core/Cargo.toml
@@ -14,3 +14,8 @@ keywords = ["video", "multimedia"]
 [dependencies]
 anyhow = "1.0.51"
 nom = "7.1.0"
+serde = { version = "1.0.164", features = ["derive"], optional = true }
+serde_json = { version = "1.0.96", optional = true }
+
+[features]
+save = ["dep:serde", "dep:serde_json"]

--- a/hdrcopier-core/src/lib.rs
+++ b/hdrcopier-core/src/lib.rs
@@ -38,6 +38,79 @@ pub fn copy(input: PathBuf, target: PathBuf, chapters: bool) {
     eprintln!("Done!");
 }
 
+#[cfg(feature = "save")]
+pub fn save(input: PathBuf, target: PathBuf, chapters: bool) {
+    if !input.is_file() {
+        eprintln!("Input file {:?} does not exist", input);
+        exit(1);
+    }
+    if input.exists() && !input.is_file() {
+        eprintln!("Target {:?} is not a file", target);
+        exit(1);
+    }
+
+    let metadata = match Metadata::parse(&input) {
+        Ok(metadata) => metadata,
+        Err(e) => {
+            eprintln!("{}", e);
+            exit(1);
+        }
+    };
+    let chapters = if chapters {
+        extract_chapters(&input)
+    } else {
+        None
+    };
+    let json = match serde_json::to_string_pretty(&(metadata, chapters)) {
+        Ok(json) => json,
+        Err(e) => {
+            eprintln!("{}", e);
+            exit(1);
+        }
+    };
+    if let Err(e) = std::fs::write(target, json) {
+        eprintln!("{}", e);
+        exit(1);
+    };
+
+    eprint!("Done!");
+}
+
+#[cfg(feature = "save")]
+pub fn restore(input: PathBuf, target: PathBuf, chapters: bool) {
+    if !input.is_file() {
+        eprintln!("Input file {:?} does not exist", input);
+        exit(1);
+    }
+    if !target.is_file() {
+        eprintln!("Target file {:?} does not exist", target);
+        exit(1);
+    }
+    let file = match std::fs::File::open(input) {
+        Ok(file) => file,
+        Err(e) => {
+            eprintln!("{}", e);
+            exit(1);
+        }
+    };
+
+    let (metadata, saved_chapters) =
+        match serde_json::from_reader::<_, (Metadata, Option<PathBuf>)>(file) {
+            Ok(metadata) => metadata,
+            Err(e) => {
+                eprintln!("{}", e);
+                exit(1);
+            }
+        };
+    let saved_chapters = if chapters { saved_chapters } else { None };
+    if let Err(e) = metadata.apply(&target, saved_chapters.as_deref()) {
+        eprintln!("{}", e);
+        exit(1);
+    };
+
+    eprintln!("Done!");
+}
+
 pub fn show(input: PathBuf, formatting: Option<&str>) {
     if !input.is_file() {
         eprintln!("Input file {:?} does not exist", input);

--- a/hdrcopier-core/src/metadata.rs
+++ b/hdrcopier-core/src/metadata.rs
@@ -25,12 +25,14 @@ use crate::{
 };
 
 #[derive(Default)]
+#[cfg_attr(feature = "save", derive(serde::Serialize, serde::Deserialize))]
 pub struct Metadata {
     pub basic: Option<BasicMetadata>,
     pub hdr: Option<HdrMetadata>,
 }
 
 #[derive(Default)]
+#[cfg_attr(feature = "save", derive(serde::Serialize, serde::Deserialize))]
 pub struct BasicMetadata {
     pub matrix: u8,
     pub range: u8,
@@ -39,6 +41,7 @@ pub struct BasicMetadata {
 }
 
 #[derive(Default)]
+#[cfg_attr(feature = "save", derive(serde::Serialize, serde::Deserialize))]
 pub struct ColorCoordinates {
     pub red: (f64, f64),
     pub green: (f64, f64),
@@ -47,6 +50,7 @@ pub struct ColorCoordinates {
 }
 
 #[derive(Default)]
+#[cfg_attr(feature = "save", derive(serde::Serialize, serde::Deserialize))]
 pub struct HdrMetadata {
     pub color_coords: Option<ColorCoordinates>,
     pub max_luma: u32,


### PR DESCRIPTION
This pull request introduces a new feature to the project that allows users to save and restore metadata to JSON files.
With these changes, users can now use the `hdrcopier save` command to save metadata from a file to a JSON file and the `hdrcopier restore` command to restore metadata from a JSON file to a target file.

There may be a nicer way of doing this by using otherwise empty mkvs instead of JSON (and I would like that better), but this is a relatively straightforward way of implementing saving and restoring.

I put the feature behind a feature gate, but that can easily be removed.

The main motivation for this feature is that it eliminates needing to have both the source and a newly encoded file when copying metadata.