### PR TITLE
Fix missing rav1e --mastering-display param when using --format

### DIFF
--- a/hdrcopier-core/src/metadata.rs
+++ b/hdrcopier-core/src/metadata.rs
@@ -226,7 +226,7 @@ impl Metadata {
             },
             if let Some(ref hdr_data) = self.hdr {
                 format!(
-                    " --content-light {},{}{}",
+                    " --content-light {},{} --mastering-display {}",
                     hdr_data.max_content_light,
                     hdr_data.max_frame_light,
                     format_master_display(


### PR DESCRIPTION
Before:
![image](https://github.com/shssoichiro/hdrcopier/assets/33820904/9e0dac46-5130-4cc9-945f-21463649ff0c)

After:
![image](https://github.com/shssoichiro/hdrcopier/assets/33820904/956c8472-f47a-43c8-9f98-0078ece5a4be)
