### PR TITLE
Feature:  `show --format` for SVT-AV1

### DIFF
--- a/hdrcopier-cli/src/main.rs
+++ b/hdrcopier-cli/src/main.rs
@@ -44,7 +44,7 @@ fn main() {
                         .long("format")
                         .short('f')
                         .takes_value(true)
-                        .possible_values(["x265", "rav1e", "mkvmerge"]),
+                        .possible_values(["x265", "svt-av1", "rav1e", "mkvmerge"]),
                 ),
         )
         .get_matches();

--- a/hdrcopier-core/src/metadata.rs
+++ b/hdrcopier-core/src/metadata.rs
@@ -11,8 +11,10 @@ use crate::{
         color_range_to_mkvedit_prop, print_color_primaries, print_color_range,
         print_matrix_coefficients, print_rav1e_color_primaries, print_rav1e_color_range,
         print_rav1e_matrix_coefficients, print_rav1e_transfer_characteristics,
-        print_transfer_characteristics, print_x265_color_primaries, print_x265_color_range,
-        print_x265_matrix_coefficients, print_x265_transfer_characteristics,
+        print_svtav1_color_primaries, print_svtav1_color_range, print_svtav1_matrix_coefficients,
+        print_svtav1_transfer_characteristics, print_transfer_characteristics,
+        print_x265_color_primaries, print_x265_color_range, print_x265_matrix_coefficients,
+        print_x265_transfer_characteristics,
     },
 };
 
@@ -118,6 +120,7 @@ impl Metadata {
         match format {
             None => self.print_human_readable_format(),
             Some("x265") => self.print_x265_args(),
+            Some("svt-av1") => self.print_svtav1_args(),
             Some("rav1e") => self.print_rav1e_args(),
             Some("mkvmerge") => self.print_mkvmerge_args(),
             _ => unreachable!("Unimplemented output format"),
@@ -203,6 +206,45 @@ impl Metadata {
                         hdr_data.max_luma,
                         hdr_data.min_luma
                     )
+                )
+            } else {
+                String::new()
+            }
+        );
+    }
+
+    fn print_svtav1_args(&self) {
+        println!(
+            "{}{}",
+            if let Some(ref basic) = self.basic {
+                format!(
+                    "--color-range {} --color-primaries {} --transfer-characteristics {} --matrix-coefficients {}",
+                    print_svtav1_color_range(basic.range),
+                    print_svtav1_color_primaries(basic.primaries),
+                    print_svtav1_transfer_characteristics(basic.transfer),
+                    print_svtav1_matrix_coefficients(basic.matrix)
+                )
+            } else {
+                String::new()
+            },
+            if let Some(ref hdr_data) = self.hdr {
+                format!(
+                    " --content-light {},{} --mastering-display {}",
+                    hdr_data.max_content_light,
+                    hdr_data.max_frame_light,
+                    format!(
+                        "G({},{})B({},{})R({},{})WP({},{})L({},{})",
+                        hdr_data.color_coords.as_ref().unwrap().green.0,
+                        hdr_data.color_coords.as_ref().unwrap().green.1,
+                        hdr_data.color_coords.as_ref().unwrap().blue.0,
+                        hdr_data.color_coords.as_ref().unwrap().blue.1,
+                        hdr_data.color_coords.as_ref().unwrap().red.0,
+                        hdr_data.color_coords.as_ref().unwrap().red.1,
+                        hdr_data.color_coords.as_ref().unwrap().white.0,
+                        hdr_data.color_coords.as_ref().unwrap().white.1,
+                        hdr_data.max_luma,
+                        hdr_data.min_luma,
+                    ),
                 )
             } else {
                 String::new()

--- a/hdrcopier-core/src/values.rs
+++ b/hdrcopier-core/src/values.rs
@@ -39,6 +39,14 @@ pub fn print_rav1e_color_range(value: u8) -> &'static str {
     }
 }
 
+pub fn print_svtav1_color_range(value: u8) -> &'static str {
+    match value {
+        0 => "full",
+        1 => "studio",
+        _ => panic!("Unrecognized color range"),
+    }
+}
+
 pub fn parse_matrix_coefficients(value: &str) -> u8 {
     match value.to_lowercase().as_str() {
         "rgb" => 0,
@@ -94,6 +102,26 @@ pub fn print_x265_matrix_coefficients(value: u8) -> &'static str {
         // gbr
         // smpte2085
         // ictcp
+        _ => panic!("Unrecognized matrix coefficients"),
+    }
+}
+
+pub fn print_svtav1_matrix_coefficients(value: u8) -> &'static str {
+    match value {
+        0 => "identity",
+        1 => "bt709",
+        2 => "unspecified",
+        4 => "fcc",
+        5 => "bt470bg",
+        6 => "bt601",
+        7 => "smpte240",
+        8 => "ycgco",
+        9 => "bt2020-ncl",
+        10 => "bt2020-cl",
+        11 => "smpte2085",
+        12 => "chroma-ncl",
+        13 => "chroma-cl",
+        14 => "ictcp",
         _ => panic!("Unrecognized matrix coefficients"),
     }
 }
@@ -186,6 +214,29 @@ pub fn print_x265_transfer_characteristics(value: u8) -> &'static str {
     }
 }
 
+pub fn print_svtav1_transfer_characteristics(value: u8) -> &'static str {
+    match value {
+        1 => "bt709",
+        2 => "unspecified",
+        4 => "bt470m",
+        5 => "bt470bg",
+        6 => "bt601",
+        7 => "smpte240",
+        8 => "linear",
+        9 => "log100",
+        10 => "log100-sqrt10",
+        11 => "iec61966",
+        12 => "bt1361",
+        13 => "srgb",
+        14 => "bt2020-10",
+        15 => "bt2020-12",
+        16 => "smpte2084",
+        17 => "smpte428",
+        18 => "hlg",
+        _ => panic!("Unrecognized matrix coefficients"),
+    }
+}
+
 pub fn print_rav1e_transfer_characteristics(value: u8) -> &'static str {
     match value {
         1 => "BT709",
@@ -261,6 +312,24 @@ pub fn print_x265_color_primaries(value: u8) -> &'static str {
         11 => "smpte431",
         12 => "smpte432",
         22 => panic!("EBU 3213 E not supported by x265"),
+        _ => panic!("Unrecognized color primaries"),
+    }
+}
+
+pub fn print_svtav1_color_primaries(value: u8) -> &'static str {
+    match value {
+        1 => "bt709",
+        2 => "unspecified",
+        4 => "bt470m",
+        5 => "bt470bg",
+        6 => "bt601",
+        7 => "smpte240",
+        8 => "film",
+        9 => "bt2020",
+        10 => "xyz",
+        11 => "smpte431",
+        12 => "smpte432",
+        22 => "ebu3213",
         _ => panic!("Unrecognized color primaries"),
     }
 }


### PR DESCRIPTION
[SVT-AV1 Paramters](https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/4580b6f25e0c6bf5805d497256b83859ae1fd3db/Docs/Parameters.md#2-av1-metadata)
Resolves #5

###### Note: The format for the mastering display string appears to be different for SVT-AV1 